### PR TITLE
Fix sanitizeTestName to allow spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const scheduler = require('./scheduler');
 const { getNextRunTime } = require('./scheduler');
 
 function sanitizeTestName(name) {
-  return path.basename(name).replace(/[^a-zA-Z0-9_-]/g, '_');
+  return path.basename(name).replace(/[^a-zA-Z0-9 _-]/g, '_');
 }
 
 const app = express();


### PR DESCRIPTION
## Summary
- preserve spaces when sanitizing test names

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6874dab11fe483329653c68e2401cc5f