### PR TITLE
Improve selector generation

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -36,25 +36,54 @@ const sessionFile = path.join(sessionDir, `${safeName}.json`);
     window.getSelector = el => {
       if (!el || el.nodeType !== 1) return '';
       const parts = [];
-      while (el && el.nodeType === 1) {
-        let part = el.tagName.toLowerCase();
-        if (el.id) {
-          part += `#${el.id}`;
-          parts.unshift(part);
-          break;
-        } else {
-          if (el.className) {
-            part += '.' + el.className.trim().split(/\s+/).join('.');
-          }
-          const siblings = Array.from(el.parentNode ? el.parentNode.children : []).filter(e => e.tagName === el.tagName);
-          if (siblings.length > 1) {
-            const index = siblings.indexOf(el) + 1;
-            part += `:nth-of-type(${index})`;
+      let curr = el;
+
+      while (curr && curr.nodeType === 1) {
+        let part = curr.tagName.toLowerCase();
+
+        if (curr.id) {
+          part += `#${CSS.escape(curr.id)}`;
+        } else if (curr.classList.length) {
+          part += Array.from(curr.classList)
+            .map(cls => `.${CSS.escape(cls)}`)
+            .join('');
+        }
+
+        let selector = parts.length ? `${part} > ${parts.join(' > ')}` : part;
+        if (document.querySelectorAll(selector).length === 1) {
+          return selector;
+        }
+
+        if (!curr.id) {
+          for (const attr of Array.from(curr.attributes)) {
+            if (attr.name.startsWith('data-')) {
+              const withData = `${part}[${attr.name}="${CSS.escape(attr.value)}"]`;
+              selector = parts.length ? `${withData} > ${parts.join(' > ')}` : withData;
+              if (document.querySelectorAll(selector).length === 1) {
+                return selector;
+              }
+              break;
+            }
           }
         }
+
+        if (curr.parentNode) {
+          const siblings = Array.from(curr.parentNode.children).filter(e => e.tagName === curr.tagName);
+          if (siblings.length > 1) {
+            const index = siblings.indexOf(curr) + 1;
+            const withNth = `${part}:nth-of-type(${index})`;
+            selector = parts.length ? `${withNth} > ${parts.join(' > ')}` : withNth;
+            if (document.querySelectorAll(selector).length === 1) {
+              return selector;
+            }
+            part = withNth;
+          }
+        }
+
         parts.unshift(part);
-        el = el.parentNode;
+        curr = curr.parentNode;
       }
+
       return parts.join(' > ');
     };
 

--- a/sessions/sample.json
+++ b/sessions/sample.json
@@ -1,0 +1,49 @@
+[
+  {
+    "type": "navigate",
+    "href": "http://localhost:3000",
+    "timestamp": 0
+  },
+  {
+    "type": "input",
+    "detail": {
+      "name": "url",
+      "value": "http://example.test",
+      "checked": false,
+      "tag": "input",
+      "type": "text",
+      "id": "url",
+      "className": "",
+      "selector": "input#url"
+    },
+    "timestamp": 1
+  },
+  {
+    "type": "input",
+    "detail": {
+      "name": "testName",
+      "value": "sample",
+      "checked": false,
+      "tag": "input",
+      "type": "text",
+      "id": "testName",
+      "className": "",
+      "selector": "input#testName"
+    },
+    "timestamp": 2
+  },
+  {
+    "type": "click",
+    "detail": {
+      "tag": "BUTTON",
+      "text": "▶ Start Recording",
+      "id": "submitBtn",
+      "name": "",
+      "className": "",
+      "href": "",
+      "type": "submit",
+      "selector": "button#submitBtn"
+    },
+    "timestamp": 3
+  }
+]


### PR DESCRIPTION
## Summary
- ensure selector uniqueness by climbing parents with CSS.escape
- use dataset attributes when classes/ID are not enough
- mirror changes in recorder CLI
- add a simple sample session

## Testing
- `node replay.js sample` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6874fda143748332a53d0c2f8c490d1b