### PR TITLE
Use CHROME_PATH env var for puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ periodically.
    ```
    The application listens on port `3000` by default. Set the `PORT` environment
    variable to use a different port.
+   If Puppeteer cannot locate Chrome, set `CHROME_PATH` to the full path of your
+   Chrome executable.
 
 ## Usage
 

--- a/replay.js
+++ b/replay.js
@@ -254,15 +254,20 @@ async function findAndClick(page, detail, targetText, stepIndex, screenshotDir, 
   const screenshotDir = path.join(__dirname, 'screenshots');
   if (!fs.existsSync(screenshotDir)) fs.mkdirSync(screenshotDir);
 
-  browser = await puppeteer.launch({
+  const launchOptions = {
     headless: 'new',
-    executablePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
       '--window-size=1920,1080'
     ]
-  });
+  };
+
+  if (process.env.CHROME_PATH) {
+    launchOptions.executablePath = process.env.CHROME_PATH;
+  }
+
+  browser = await puppeteer.launch(launchOptions);
 
   const page = await browser.newPage();
   await page.setViewport({ width: 1920, height: 1080 });


### PR DESCRIPTION
## Summary
- add dynamic `executablePath` support in `replay.js`
- document the optional `CHROME_PATH` variable in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687502663d748332b14b90d8f9d9ffbb