### PR TITLE
Debounce input events when recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ periodically.
 
 ## Features
 
-- Record click and form input events from any URL
+- Record click events and debounced form inputs (checkboxes and radios record instantly)
 - Replay recorded tests with screenshots and optional device emulation
 - Queue and schedule tests to run automatically
 - View test status and manage recorded sessions from the browser
@@ -32,8 +32,7 @@ periodically.
 
 Open your browser to `http://localhost:3000` and follow the on‑screen
 instructions to create a new test. When recording starts, a separate browser
-window is launched and all navigation, clicks and inputs are stored in
-`/sessions/<testName>.json`.
+window is launched and all navigation, clicks and inputs are stored in `/sessions/<testName>.json`. Inputs in text fields are recorded after 300ms of inactivity, while checkboxes and radio buttons are saved immediately.
 
 Recorded tests can be replayed from the main page or scheduled to run at regular
 intervals from `/schedule`. Screenshots and logs produced during replay are

--- a/lib/recorderHelpers.js
+++ b/lib/recorderHelpers.js
@@ -40,34 +40,71 @@ function extractDetails(el) {
 function registerListeners(recordFnName = 'recordEvent') {
   window._lastAction = { type: null, el: null, time: 0 };
 
-  document.addEventListener('click', e => {
-    const now = Date.now();
-    window._lastAction = { type: 'click', el: e.target, time: now };
-    const detail = extractDetails(e.target);
-    window[recordFnName]({
-      type: 'click',
-      detail,
-      timestamp: now
-    });
-  }, true);
+  // keep debounce timers per element
+  const inputTimers = new WeakMap();
 
-  document.addEventListener('input', e => {
-    const now = Date.now();
-    if (
-      window._lastAction.type === 'click' &&
-      (window._lastAction.el === e.target || window._lastAction.el.contains(e.target)) &&
-      now - window._lastAction.time < 300
-    ) {
-      console.log('⚠️ Skipped input caused by click');
-      return;
-    }
-    const detail = extractDetails(e.target);
-    window[recordFnName]({
-      type: 'input',
-      detail,
-      timestamp: now
-    });
-  }, true);
+  document.addEventListener(
+    'click',
+    (e) => {
+      const now = Date.now();
+      window._lastAction = { type: 'click', el: e.target, time: now };
+      const detail = extractDetails(e.target);
+      window[recordFnName]({
+        type: 'click',
+        detail,
+        timestamp: now,
+      });
+    },
+    true
+  );
+
+  document.addEventListener(
+    'input',
+    (e) => {
+      const now = Date.now();
+      const el = e.target;
+
+      if (
+        el.type !== 'checkbox' &&
+        el.type !== 'radio' &&
+        window._lastAction.type === 'click' &&
+        (window._lastAction.el === el || window._lastAction.el.contains(el)) &&
+        now - window._lastAction.time < 300
+      ) {
+        console.log('⚠️ Skipped input caused by click');
+        return;
+      }
+
+      // checkboxes and radios are recorded instantly
+      if (el.type === 'checkbox' || el.type === 'radio') {
+        const detail = extractDetails(el);
+        window[recordFnName]({ type: 'input', detail, timestamp: now });
+        return;
+      }
+
+      // debounce text inputs
+      if (inputTimers.has(el)) {
+        clearTimeout(inputTimers.get(el).timer);
+      }
+
+      const entry = {
+        detail: extractDetails(el),
+        timer: null,
+      };
+
+      entry.timer = setTimeout(() => {
+        window[recordFnName]({
+          type: 'input',
+          detail: entry.detail,
+          timestamp: Date.now(),
+        });
+        inputTimers.delete(el);
+      }, 300);
+
+      inputTimers.set(el, entry);
+    },
+    true
+  );
 }
 
 function setupRecorder(recordFnName = 'recordEvent') {


### PR DESCRIPTION
## Summary
- debounce input events inside `registerListeners`
- document new input recording behaviour

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875082ae380833288c9187754068ee7