### PR TITLE
Improve click reliability with retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Set an environment variable to `false` (e.g. `FIND_AND_CLICK_BY_NAME=false`) or
 use the corresponding `--no-` flag to disable that step. Omitting these options
 keeps all fallbacks enabled, preserving the default behaviour.
 
+Each click is retried until the element becomes available. The default timeout
+is 10 seconds with a 500ms polling interval. Adjust these using the
+`CLICK_TIMEOUT` and `CLICK_RETRY_INTERVAL` environment variables.
+
 ## Directory overview
 
 - `index.js` – Express server and HTTP API

--- a/replay.js
+++ b/replay.js
@@ -13,6 +13,9 @@ if (!testName) {
   process.exit(1);
 }
 
+const CLICK_TIMEOUT = parseInt(process.env.CLICK_TIMEOUT, 10) || 10000;
+const CLICK_RETRY_INTERVAL = parseInt(process.env.CLICK_RETRY_INTERVAL, 10) || 500;
+
 function getOption(flag, envVar, def = true) {
   if (process.env[envVar] !== undefined) {
     return !/^(false|0)$/i.test(process.env[envVar]);
@@ -231,8 +234,12 @@ async function findAndClick(page, detail, targetText, stepIndex, screenshotDir, 
     });
   }
 
-  for (const attempt of attempts) {
-    if (await attempt()) return true;
+  const end = Date.now() + CLICK_TIMEOUT;
+  while (Date.now() < end) {
+    for (const attempt of attempts) {
+      if (await attempt()) return true;
+    }
+    await sleep(CLICK_RETRY_INTERVAL);
   }
 
   await handleFailure(page, stepIndex, testName, screenshotDir, `Could not click "${targetText}"`);


### PR DESCRIPTION
## Summary
- retry clicking elements in `replay.js` until they appear
- document click timeout and retry interval in README

## Testing
- ❌ `apt-get update` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6875e688b4c88332ac1459d204ea7a25