### PR TITLE
Enable device emulation when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ periodically.
 
 Open your browser to `http://localhost:3000` and follow the on‑screen
 instructions to create a new test. When recording starts, a separate browser
-window is launched and all navigation, clicks and inputs are stored in `/sessions/<testName>.json`. Inputs in text fields are recorded after 300ms of inactivity, while checkboxes and radio buttons are saved immediately.
+window is launched and all navigation, clicks and inputs are stored in `/sessions/<testName>.json` along with the chosen device. Inputs in text fields are recorded after 300ms of inactivity, while checkboxes and radio buttons are saved immediately.
 
 Recorded tests can be replayed from the main page or scheduled to run at regular
-intervals from `/schedule`. Screenshots and logs produced during replay are
+intervals from `/schedule`. When a session is replayed, the saved device setting
+is automatically applied. Screenshots and logs produced during replay are
 stored in the `screenshots` directory.
+
+### Device emulation
+
+The device name selected when recording is matched against Puppeteer’s built-in
+descriptors. Friendly aliases are provided so options like `Samsung Galaxy S9`
+or `iPhone 11` work out of the box. If no descriptor is found the test falls
+back to desktop mode and a warning is logged.
 
 ## Click fallback configuration
 

--- a/public/main.js
+++ b/public/main.js
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const li = document.createElement('li');
                 li.innerHTML = `
                     <div>
-                        <strong>${t.name}</strong><br/>
+                        <strong>${t.name}</strong> <span style="color:#666;">(${t.device})</span><br/>
                         <a href="${t.href}" target="_blank" style="font-size: 0.9em; color: #666; text-decoration: underline;">${t.href}</a>
                     </div>
                     <div>

--- a/public/schedule.html
+++ b/public/schedule.html
@@ -85,7 +85,8 @@
             });
 
             label.appendChild(checkbox);
-            label.appendChild(document.createTextNode(` ${test.name}`));
+            const labelText = ` ${test.name}${test.device ? ' (' + test.device + ')' : ''}`;
+            label.appendChild(document.createTextNode(labelText));
 
             div.appendChild(label);
 


### PR DESCRIPTION
## Summary
- map friendly device names to Puppeteer's descriptors
- store mapped device names in new recordings
- emulate the saved device when replaying sessions
- show recorded device in the UI and schedule page
- document alias behaviour in the README

## Testing
- `node -v`
- `npm install` *(fails: network restricted)*


------
https://chatgpt.com/codex/tasks/task_e_687607eff0ac8332bf19833b21ad850a