### PR TITLE
Add basic automatic crawling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ periodically.
 - Replay recorded tests with screenshots and optional device emulation
 - Queue and schedule tests to run automatically
 - View test status and manage recorded sessions from the browser
+- Automatic exploratory mode for quickly crawling a URL
 
 ## Installation
 
@@ -68,6 +69,14 @@ keeps all fallbacks enabled, preserving the default behaviour.
 Each click is retried until the element becomes available. The default timeout
 is 10 seconds with a 500ms polling interval. Adjust these using the
 `CLICK_TIMEOUT` and `CLICK_RETRY_INTERVAL` environment variables.
+
+### Automatic mode
+
+Send a `POST` request to `/auto` with a JSON body containing a `url` and optional
+`device` to run a quick exploratory crawl. The browser navigates to the page,
+attempts to fill text inputs and follows a few links while capturing
+screenshots and logs in the `screenshots` directory. A simple form on the main
+page lets you trigger this mode from the browser.
 
 ## Directory overview
 

--- a/autoRunner.js
+++ b/autoRunner.js
@@ -1,0 +1,97 @@
+const puppeteer = require('puppeteer');
+const devices = puppeteer.devices;
+const fs = require('fs');
+const path = require('path');
+
+const deviceAliases = {
+  'Samsung Galaxy S9': 'Galaxy S9+',
+  'iPhone 11': 'iPhone 11',
+  'iPad': 'iPad'
+};
+function mapDevice(name) {
+  return deviceAliases[name] || name;
+}
+
+const [, , targetUrl, deviceArg] = process.argv;
+if (!targetUrl) {
+  console.error('Usage: node autoRunner.js <URL> [device]');
+  process.exit(1);
+}
+
+const maxDepth = 1;
+const visited = new Set();
+const screenshotDir = path.join(__dirname, 'screenshots');
+if (!fs.existsSync(screenshotDir)) fs.mkdirSync(screenshotDir, { recursive: true });
+
+const logData = {
+  consoleMessages: [],
+  pageErrors: [],
+  networkRequests: []
+};
+
+(async () => {
+  const device = mapDevice(deviceArg || 'desktop');
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+
+  if (device && device !== 'desktop') {
+    if (devices[device]) {
+      await page.emulate(devices[device]);
+    } else {
+      console.warn(`Device descriptor for "${device}" not found, using desktop.`);
+    }
+  }
+
+  page.on('console', msg => logData.consoleMessages.push({
+    type: msg.type(), text: msg.text(), location: msg.location()
+  }));
+  page.on('pageerror', err => logData.pageErrors.push({ message: err.message, stack: err.stack }));
+  page.on('requestfinished', async req => {
+    try {
+      const res = await req.response();
+      const body = await res.text();
+      logData.networkRequests.push({
+        url: req.url(),
+        method: req.method(),
+        status: res.status(),
+        headers: res.headers(),
+        requestPostData: req.postData(),
+        responseBody: body.slice(0, 1000)
+      });
+    } catch (err) {
+      logData.networkRequests.push({ url: req.url(), error: err.message });
+    }
+  });
+
+  async function visit(url, depth) {
+    if (depth > maxDepth || visited.has(url)) return;
+    visited.add(url);
+    console.log('Visiting', url);
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+    const screenshotPath = path.join(screenshotDir, `auto-${Date.now()}.png`);
+    await page.screenshot({ path: screenshotPath });
+
+    await page.$$eval('input[type="text"],input[type="email"],textarea', inputs => {
+      inputs.forEach((input, i) => { if (!input.value) input.value = `test${i}`; });
+    });
+
+    const links = await page.$$eval('a[href]', as => as.map(a => a.href).slice(0,3));
+    for (const link of links) {
+      if (!visited.has(link)) {
+        await visit(link, depth + 1);
+        await page.goBack({ waitUntil: 'domcontentloaded' }).catch(() => {});
+      }
+    }
+  }
+
+  await visit(targetUrl, 0);
+
+  const logPath = path.join(screenshotDir, `auto-log-${Date.now()}.json`);
+  fs.writeFileSync(logPath, JSON.stringify(logData, null, 2));
+
+  await browser.close();
+})();

--- a/index.js
+++ b/index.js
@@ -194,6 +194,22 @@ app.post('/record', async (req, res) => {
   }
 });
 
+app.post('/auto', (req, res) => {
+  const { url, device } = req.body;
+  if (!url) return res.status(400).send('Missing URL');
+
+  const args = ['autoRunner.js', url];
+  if (device) args.push(device);
+
+  const child = spawn('node', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+  child.stdout.on('data', data => console.log(`[autoRunner stdout]: ${data}`));
+  child.stderr.on('data', data => console.error(`[autoRunner stderr]: ${data}`));
+  child.on('close', code => console.log(`autoRunner exited with code ${code}`));
+
+  res.json({ status: 'started' });
+});
+
 app.delete('/delete/:testName', (req, res) => {
   const testName = sanitizeTestName(req.params.testName);
   const filesToDelete = [

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,20 @@
         <button type="submit" id="submitBtn">▶ Start Recording</button>
     </form>
 
+    <form id="autoForm" style="margin-top:2rem;" novalidate>
+        <h2>Automatic Mode</h2>
+
+        <label for="autoUrl">🔗 URL to test:</label>
+        <input type="text" name="url" id="autoUrl" placeholder="https://example.com" required>
+
+        <label for="autoDevice" style="display:block;margin-top:1rem;">Select device:</label>
+        <select name="device" id="autoDevice" style="margin-top:0.25rem;margin-bottom:1rem;"></select>
+
+        <button type="submit" id="autoBtn">▶ Run Automatically</button>
+    </form>
+
+    <div id="autoMessage" style="margin-bottom:2rem; font-weight:bold;"></div>
+
     <div id="recordMessage" style="margin-bottom: 2rem; font-weight: bold;"></div>
 
     <div class="test-list">

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
     const recordForm = document.getElementById('recordForm');
+    const autoForm = document.getElementById('autoForm');
+
+    const autoDeviceSelect = document.getElementById('autoDevice');
+    const autoMessage = document.getElementById('autoMessage');
+    const autoBtn = document.getElementById('autoBtn');
 
     // Create device label and selector dynamically
     const deviceLabel = document.createElement('label');
@@ -26,6 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
         option.value = d.value;
         option.textContent = d.name;
         deviceSelect.appendChild(option);
+        if (autoDeviceSelect) {
+            autoDeviceSelect.appendChild(option.cloneNode(true));
+        }
     });
 
     recordForm.insertBefore(deviceLabel, recordForm.querySelector('button'));
@@ -84,6 +92,41 @@ document.addEventListener('DOMContentLoaded', () => {
             submitBtn.disabled = false;
         }
     });
+
+    if (autoForm) {
+        autoForm.addEventListener('submit', async function (event) {
+            event.preventDefault();
+
+            const urlInput = this.url;
+            const device = autoDeviceSelect.value;
+            const url = urlInput.value.trim();
+            if (!url) {
+                alert('Please enter a URL.');
+                return;
+            }
+
+            autoBtn.disabled = true;
+            autoMessage.textContent = 'Running automatic test...';
+
+            try {
+                const res = await fetch('/auto', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ url, device })
+                });
+                if (res.ok) {
+                    autoMessage.textContent = 'Automatic run started.';
+                } else {
+                    autoMessage.textContent = 'Failed to start.';
+                }
+            } catch {
+                autoMessage.textContent = 'Error starting automatic run.';
+            }
+
+            autoBtn.disabled = false;
+            urlInput.value = '';
+        });
+    }
 
     // Existing code for listing tests remains unchanged
     fetch('/tests')


### PR DESCRIPTION
## Summary
- implement `autoRunner.js` to crawl a URL and take screenshots
- expose `/auto` API endpoint to trigger the auto runner
- add form in `index.html` and JS logic in `main.js` for automatic mode
- document the feature in `README.md`

## Testing
- `node autoRunner.js https://example.com` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_687677fd9fb88332b977efa29bfa8209